### PR TITLE
move oracle connection string to app config

### DIFF
--- a/Model/OracleDB.cs
+++ b/Model/OracleDB.cs
@@ -8,9 +8,13 @@ namespace Model
 {
     public class OracleDB : DbContext
     {
-        public OracleDB() : base(new OracleConnection("User Id=OT;Password=Orcl1234;Data Source=localhost:1521/XEPDB1;"), true)
+        public OracleDB() : base("name=SchemaOT")
         {
         }
+        public OracleDB(string connectionString) : base(connectionString)
+        {
+        }
+
         protected override void OnModelCreating(DbModelBuilder modelBuilder)
         {
             base.OnModelCreating(modelBuilder);

--- a/View/App.config
+++ b/View/App.config
@@ -43,6 +43,6 @@
   </oracle.manageddataaccess.client>
   <connectionStrings>
     <add name="OracleDbContext" providerName="Oracle.ManagedDataAccess.Client" connectionString="User Id=oracle_user;Password=oracle_user_password;Data Source=oracle"/>
-    <add name="chemaOT" connectionString="User Id=OT;Password=Orcl1234;Data Source=localhost:1521/ORCLPDB;" providerName="Oracle.ManagedDataAccess.Client"/>
+    <add name="SchemaOT" connectionString="User Id=OT;Password=Orcl1234;Data Source=localhost:1521/ORCLPDB;" providerName="Oracle.ManagedDataAccess.Client"/>
   </connectionStrings>
 </configuration>

--- a/View/App.config
+++ b/View/App.config
@@ -43,5 +43,6 @@
   </oracle.manageddataaccess.client>
   <connectionStrings>
     <add name="OracleDbContext" providerName="Oracle.ManagedDataAccess.Client" connectionString="User Id=oracle_user;Password=oracle_user_password;Data Source=oracle"/>
+    <add name="chemaOT" connectionString="User Id=OT;Password=Orcl1234;Data Source=localhost:1521/ORCLPDB;" providerName="Oracle.ManagedDataAccess.Client"/>
   </connectionStrings>
 </configuration>


### PR DESCRIPTION
No idea why the connection string has to be in the View/App.config or why the second constructor is needed... but it works.